### PR TITLE
Switch from peerDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,6 @@
     "eslint": "^4.19",
     "prettier": "^1.19.1"
   },
-  "devDependencies": {
-    "eslint": "^4.19",
-    "babel-eslint": "^8.2",
-    "prettier": "^1.19.1"
-  },
-  "peerDependencies": {},
   "scripts": {
     "test": "eslint --ignore-pattern !.* *.js .*.js"
   },

--- a/package.json
+++ b/package.json
@@ -3,17 +3,17 @@
   "version": "1.0.7",
   "description": "Shareable eslint config for Discourse and plugins",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "babel-eslint": "^8.2",
+    "eslint": "^4.19",
+    "prettier": "^1.19.1"
+  },
   "devDependencies": {
     "eslint": "^4.19",
     "babel-eslint": "^8.2",
     "prettier": "^1.19.1"
   },
-  "peerDependencies": {
-    "babel-eslint": "^8.2",
-    "eslint": "^4.19",
-    "prettier": "^1.19.1"
-  },
+  "peerDependencies": {},
   "scripts": {
     "test": "eslint --ignore-pattern !.* *.js .*.js"
   },


### PR DESCRIPTION
The main reason for this is so that dependencies are included when doing `yarn install` on another package that includes `eslint-config-discourse`. 
