### PR TITLE
DEV: enforces no-var in our codebase

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ module.exports = {
     "no-undef": 2,
     "no-unused-vars": 2,
     "no-with": 2,
+    "no-var": 2,
     radix: 2,
     semi: 2,
     strict: 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-discourse",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Shareable eslint config for Discourse and plugins",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Note that this rule can be auto fixed by --fix most of the times.