### PR TITLE
DEV: adds no-duplicate-imports/sort-imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,5 +102,12 @@ module.exports = {
     "valid-typeof": 2,
     "wrap-iife": [2, "inside"],
     curly: 2,
+    "no-duplicate-imports": 2,
+    "sort-imports": [
+      "error",
+      {
+        ignoreDeclarationSort: true,
+      },
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-discourse",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Shareable eslint config for Discourse and plugins",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Note that declarations sorting is disabled for now as it's not auto-fixable with --fix : https://eslint.org/docs/rules/sort-imports