### PR TITLE
DEV: Move template-tag to bottom of class definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,6 @@ module.exports = {
       2,
       {
         order: [
-          "[template-tag]",
           "[static-properties]",
           "[static-methods]",
           "[injected-services]",
@@ -136,6 +135,7 @@ module.exports = {
           "[private-properties]",
           "constructor",
           "[everything-else]",
+          "[template-tag]",
         ],
         groups: {
           // https://github.com/ember-cli/eslint-plugin-ember/issues/1896


### PR DESCRIPTION
This seems to be the more common convention in the wider ember community. Arguably it makes more sense because you define the fields/getters/functions first, and then make use of them in the `<template>`.

Unfortunately the auto-fix for this rule doesn't work properly for template-tag, so we'll have to fix this up manually in our gjs files.